### PR TITLE
Various fixes and tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lua51 = ["mlua/lua51"]
 lua52 = ["mlua/lua52"]
 lua53 = ["mlua/lua53"]
 lua54 = ["mlua/lua54"]
-default = ["prosody-log", "lua52"]
+default = ["prosody-log", "lua54"]
 
 [profile.release]
 debug = true

--- a/net/server_rust.lua
+++ b/net/server_rust.lua
@@ -59,8 +59,8 @@ return {
 	end;
 
 	-- TLS FUNCTIONS
-	tls_builder = function()
-		return sslconfig._new(server_impl.new_tls_config);
+	tls_builder = function(basepath)
+		return sslconfig._new(server_impl.new_tls_config, basepath);
 	end,
 
 	-- BARE FD FUNCTIONS

--- a/net/server_rust.lua
+++ b/net/server_rust.lua
@@ -88,7 +88,7 @@ return {
 	set_config = function(new_config)
 		local ok, err = server_impl.reconfigure(new_config);
 		if not ok then
-			module:log("error", "failed to configure network backend: %s", err)
+			log("error", "Failed to configure network backend: %s", err)
 		end
 	end;
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -400,6 +400,9 @@ fn protocol_str(p: rustls::ProtocolVersion) -> &'static str {
 		rustls::ProtocolVersion::TLSv1_1 => "TLSv1.1",
 		rustls::ProtocolVersion::TLSv1_2 => "TLSv1.2",
 		rustls::ProtocolVersion::TLSv1_3 => "TLSv1.3",
+		rustls::ProtocolVersion::DTLSv1_0 => "DTLSv1.0",
+		rustls::ProtocolVersion::DTLSv1_2 => "DTLSv1.2",
+		rustls::ProtocolVersion::DTLSv1_3 => "DTLSv1.3",
 		rustls::ProtocolVersion::Unknown(_) => "unknown"
 	}
 }


### PR DESCRIPTION
Sorry, too lazy to split these into separate branches.

Fixes a build error
```
error[E0004]: non-exhaustive patterns: `tokio_rustls::rustls::ProtocolVersion::DTLSv1_0`, `tokio_rustls::rustls::ProtocolVersion::DTLSv1_2` and `tokio_rustls::rustls::ProtocolVersion::DTLSv1_3` not covered
   --> src/tls.rs:396:8
    |
396 |     match p {
    |           ^ patterns `tokio_rustls::rustls::ProtocolVersion::DTLSv1_0`, `tokio_rustls::rustls::ProtocolVersion::DTLSv1_2` and `tokio_rustls::rustls::ProtocolVersion::DTLSv1_3` not covered
```

I suppose it could use some default case instead of handling those DTLS versions, but I got it to build so I could go back to testing stuff.

Removes use of the Prosody module API outside of a regular module (the plugin kind).

Passes a path argument along to the TLS context config builder.

And finally, make Lua 5.4 the default because it is my favorite!